### PR TITLE
Mysqli support

### DIFF
--- a/db.php
+++ b/db.php
@@ -1046,7 +1046,6 @@ class LudicrousDB extends wpdb {
 
 		$dbh = $this->get_db_object( $dbh_or_table );
 
-		if ( ! empty( $dbh ) ) {
 			if ( $this->use_mysqli ) {
 				if ( mysqli_ping( $dbh ) ) {
 					return true;

--- a/db.php
+++ b/db.php
@@ -863,6 +863,9 @@ class LudicrousDB extends wpdb {
 	 */
 	public function set_sql_mode( $modes = array(), $dbh_or_table = false ) {
 		$dbh = $this->get_db_object( $dbh_or_table );
+		if ( $this->dbh_type_check( $dbh ) ) {
+			return;
+		}
 		if ( empty( $modes ) ) {
 			if ( $this->use_mysqli ) {
 				$res = mysqli_query( $dbh, 'SELECT @@SESSION.sql_mode' );
@@ -918,7 +921,9 @@ class LudicrousDB extends wpdb {
 	 */
 	public function select( $db, $dbh_or_table = false ) {
 		$dbh = $this->get_db_object( $dbh_or_table );
-
+		if ( ! $this->dbh_type_check( $dbh ) ) {
+			return false;
+		}
 		if ( $this->use_mysqli ) {
 			$success = mysqli_select_db( $dbh, $db );
 		} else {
@@ -1046,6 +1051,7 @@ class LudicrousDB extends wpdb {
 
 		$dbh = $this->get_db_object( $dbh_or_table );
 
+		if ( $this->dbh_type_check( $dbh ) ) {
 			if ( $this->use_mysqli ) {
 				if ( mysqli_ping( $dbh ) ) {
 					return true;

--- a/db.php
+++ b/db.php
@@ -720,19 +720,25 @@ class LudicrousDB extends wpdb {
 				$this->last_connection  = compact( 'dbhname', 'host', 'port', 'user', 'name', 'tcp', 'elapsed', 'success' );
 				$this->db_connections[] = $this->last_connection;
 
-				if ( $this->use_mysqli ) {
-					$error = mysqli_error( $this->dbhs[ $dbhname ] );
-					$errno = mysqli_errno( $this->dbhs[ $dbhname ] );
-				} else {
-					$error = mysql_error( $this->dbhs[ $dbhname ] );
-					$errno = mysql_errno( $this->dbhs[ $dbhname ] );
+				if ( $this->dbh_type_check( $this->dbhs[ $dbhname ] ) ) {
+					if ( $this->use_mysqli ) {
+						$error = mysqli_error( $this->dbhs[ $dbhname ] );
+						$errno = mysqli_errno( $this->dbhs[ $dbhname ] );
+					} else {
+						$error = mysql_error( $this->dbhs[ $dbhname ] );
+						$errno = mysql_errno( $this->dbhs[ $dbhname ] );
+					}
 				}
 
 				$msg = date( "Y-m-d H:i:s" ) . " Can't select $dbhname - \n";
 				$msg .= "'referrer' => '{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}',\n";
 				$msg .= "'host' => {$host},\n";
-				$msg .= "'error' => " . $error . ",\n";
-				$msg .= "'errno' => " . $errno . ",\n";
+				if ( ! empty( $error ) ) {
+					$msg .= "'error' => " . $error . ",\n";
+				}
+				if ( ! empty( $errno ) ) {
+					$msg .= "'errno' => " . $errno . ",\n";
+				}
 				$msg .= "'tcp_responsive' => " . ( $tcp === true
 						? 'true'
 						: $tcp ) . ",\n";
@@ -1221,10 +1227,12 @@ class LudicrousDB extends wpdb {
 		}
 
 		// If there is an error then take note of it
-		if ( $this->use_mysqli ) {
-			$this->last_error = mysqli_error( $this->dbh );
-		} else {
-			$this->last_error = mysql_error( $this->dbh );
+		if ( $this->dbh_type_check( $this->dbh ) ) {
+			if ( $this->use_mysqli ) {
+				$this->last_error = mysqli_error( $this->dbh );
+			} else {
+				$this->last_error = mysql_error( $this->dbh );
+			}
 		}
 
 		if ( ! empty( $this->last_error ) ) {


### PR DESCRIPTION
Surprising hyperdb doesn't support mysqli. There are forks out that do [mysqli](https://github.com/soulseekah/hyperdb-mysqli) by @soulseekah . But this fork doesn't support falling back if mysqli is not present. 

This pull request tries to map as close to WP core naming, with the following methods being synced from core. 

- check_connection
- select
- set_sql_mode
- _do_query

Currently testing this in our testing environment. Results looking good. 

Fixes #4 