### PR TITLE
Mysqli bug fix

### DIFF
--- a/db.php
+++ b/db.php
@@ -1297,16 +1297,17 @@ class LudicrousDB extends wpdb {
 			// Return number of rows affected
 			$return_val = $this->rows_affected;
 		} else {
-			$this->load_col_info();
 			$num_rows          = 0;
 			$this->last_result = array();
 
 			if ( ( true === $this->use_mysqli ) && ( $this->result instanceof mysqli_result ) ) {
+				$this->load_col_info();
 				while ( $row = mysqli_fetch_object( $this->result ) ) {
 					$this->last_result[ $num_rows ] = $row;
 					$num_rows ++;
 				}
 			} elseif ( is_resource( $this->result ) ) {
+				$this->load_col_info();
 				while ( $row = mysql_fetch_object( $this->result ) ) {
 					$this->last_result[ $num_rows ] = $row;
 					$num_rows ++;


### PR DESCRIPTION
Fix an issue where sometimes $this->result wasn't the correct type (boolean). It is an edge case but I have seen some explains in my error logs. 

```
PHP Warning:  mysqli_num_fields() expects parameter 1 to be mysqli_result, boolean given in /<path>/wp-content/db.php on line 963

```